### PR TITLE
remove default email and only use form ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ url    : "" # the base hostname & protocol for your site, e.g. http://example.co
 baseurl: "" # the subpath of your site, e.g. /blog
 
 title      : Markeverse | Make The Pie Bigger!
-email      : support@markeverse.com #this is also the email contact forms will go to
+email      : # if set, form submissions will go to this email  ### DOESN'T WORK, USE ID BASED (see bottom) ### 
 description: "Creating more opportunities and greater value for everyone by growing the whole pie"
 author     : Markeverse Team
 # logo:     #optional, defaults to site title


### PR DESCRIPTION
So, because `email` was also set in `_config.yml` file, the code prioritized the email over the form ID. Now, email has been commented out.

Note that in #7, the entire condition on using email or form ID was removed to only have form ID. But it seems again, the source code overrides your modifications if values are incorrect. sorta either you follow the rules, or your entire modification is being replaced by the default one.