### PR TITLE
Add *Join Us* section to the website

### DIFF
--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -42,6 +42,16 @@ en: &DEFAULT_EN
     text: "Explore our ongoing and upcoming projects, showcasing the exciting ventures we're dedicated to."
     section: portfolio
     closebutton: "Close Project"
+  
+  join:
+    title: "Join Us"
+    text: ""
+    body: "At Markeverse we are going to make the pie bigger, for everyone!! You can be a part of it!\n
+
+            If you are dreaming about making your own team, and your skilled in leading people but you have no chance in your current company or career to be a leader, here is your opportunity!\n"
+    section: join
+    button: Careers
+    buttonlink: /careers/
 
   contact:
     title: "Contact Us"

--- a/_includes/join.html
+++ b/_includes/join.html
@@ -1,0 +1,19 @@
+<!-- Join Us -->
+<section class="page-section" id="{{ site.data.sitetext[site.locale].join.section | default: "join" }}">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12 text-center">
+        <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].join.title | default: "Join Us" }}</h2>
+        <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].join.text | default: "" }}</h3>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-lg-8 mx-auto text-center">
+        <div class="large text-muted">{{ site.data.sitetext[site.locale].join.body | markdownify }}</div>
+        <a class="btn btn-primary btn-xl text-uppercase" href="{{ site.data.sitetext[site.locale].join.buttonlink }}">{{ site.data.sitetext[site.locale].join.button }}</a>
+      </div>
+    </div>
+    </div>
+  </div>
+</section>
+<!-- End join -->

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,4 +6,5 @@ layout: default
 {% include about.html %}
 {% include services.html %}
 {% include portfolio_grid.html %}
+{% include join.html %}
 {% include contact.html %}


### PR DESCRIPTION
Just for good measure, there is a primary button that redirects to `/careers/`, i.e., the website deployed by https://github.com/markeverse/careers repo